### PR TITLE
Brings ORM upgrades back

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -40,9 +40,9 @@
 	var/point_upgrade_temp = 1
 	var/ore_multiplier_temp = 1
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		ore_multiplier_temp = 0.65 + (0.20 * B.rating)
+		ore_multiplier_temp = 0.80 + (0.20 * B.rating)
 	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
-		point_upgrade_temp = 0.65 + (0.20 * L.rating)
+		point_upgrade_temp = 0.80 + (0.20 * L.rating)
 	point_upgrade = point_upgrade_temp
 	ore_multiplier = round(ore_multiplier_temp, 0.01)
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -35,6 +35,17 @@
 	materials = null
 	return ..()
 
+
+/obj/machinery/mineral/ore_redemption/RefreshParts()
+	var/point_upgrade_temp = 1
+	var/ore_multiplier_temp = 1
+	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+		ore_multiplier_temp = 0.65 + (0.35 * B.rating)
+	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
+		point_upgrade_temp = 0.65 + (0.35 * L.rating)
+	point_upgrade = point_upgrade_temp
+	ore_multiplier = round(ore_multiplier_temp, 0.01)
+
 /obj/machinery/mineral/ore_redemption/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -40,9 +40,9 @@
 	var/point_upgrade_temp = 1
 	var/ore_multiplier_temp = 1
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		ore_multiplier_temp = 0.65 + (0.35 * B.rating)
+		ore_multiplier_temp = 0.65 + (0.20 * B.rating)
 	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
-		point_upgrade_temp = 0.65 + (0.35 * L.rating)
+		point_upgrade_temp = 0.65 + (0.20 * L.rating)
 	point_upgrade = point_upgrade_temp
 	ore_multiplier = round(ore_multiplier_temp, 0.01)
 


### PR DESCRIPTION
## About The Pull Request

Removing point upgrades was a mistake, it's /tg/ fixing problems for /tg/, but our servers just dont have the same playerbase or problem. A permanent t1 ORM means less mats for the station, and since this server plans on becoming beginner-friendly, we should expect most miners to die early, giving more work to do for the others.

## Why It's Good For The Game

The station needs enough mats to sustain itself

## Changelog
:cl:
add: ORM upgrades are back, although nerfed.
/:cl: